### PR TITLE
- Раздача ip по DHCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,7 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "clap",
+ "crossbeam",
  "dashmap",
  "ed25519-dalek",
  "env_logger",
@@ -1670,6 +1671,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/anet-server/Cargo.toml
+++ b/anet-server/Cargo.toml
@@ -33,6 +33,7 @@ arc-swap = "1.6"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 anet-common = { path = "../anet-common" }
+crossbeam = "0.8.4"
 
 [[bin]]
 name = "anet-server"

--- a/anet-server/src/auth_handler.rs
+++ b/anet-server/src/auth_handler.rs
@@ -161,7 +161,7 @@ impl ServerAuthHandler {
         };
         if req.client_id != temp_info.client_fingerprint { return Err(anyhow::anyhow!("Client ID mismatch")); }
 
-        let assigned_ip = self.registry.allocate_ip().context("IP POOL DEPLETED")?.to_string();
+        let assigned_ip = self.registry.allocate_ip(req.client_id).context("IP POOL DEPLETED")?.to_string();
         let session_id = generate_seid();
         let nonce_prefix = generate_unique_nonce_prefix(self.registry.clone());
 

--- a/anet-server/src/client_registry.rs
+++ b/anet-server/src/client_registry.rs
@@ -79,8 +79,8 @@ impl ClientRegistry {
         info!("[Registry] Client {} removed.", client_ip);
     }
 
-    pub fn allocate_ip(&self) -> Option<Ipv4Addr> {
-        self.ip_pool.allocate()
+    pub fn allocate_ip(&self, client_id: String) -> Option<Ipv4Addr> {
+        self.ip_pool.allocate(client_id)
     }
 
     pub fn get_by_addr(&self, remote_addr: &SocketAddr) -> Option<Arc<ClientTransportInfo>> {

--- a/anet-server/src/ip_pool.rs
+++ b/anet-server/src/ip_pool.rs
@@ -1,6 +1,15 @@
-use dashmap::DashSet;
+use crossbeam::queue::SegQueue;
+use dashmap::DashMap;
 use std::net::Ipv4Addr;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[derive(Clone)]
+pub struct Lease {
+    pub ip: Ipv4Addr,
+    pub client_id: String,
+    pub expires_at: Instant,
+}
 
 #[derive(Clone)]
 pub struct IpPool {
@@ -9,7 +18,12 @@ pub struct IpPool {
     pub gateway: Ipv4Addr,
     pub server: Ipv4Addr,
     pub mtu: u16,
-    used: Arc<DashSet<Ipv4Addr>>,
+
+    lease_time: Duration,
+
+    client_to_lease: Arc<DashMap<String, Lease>>,
+    ip_to_lease: Arc<DashMap<Ipv4Addr, Lease>>,
+    free_ips: Arc<SegQueue<Ipv4Addr>>,
 }
 
 impl IpPool {
@@ -20,44 +34,78 @@ impl IpPool {
         server: Ipv4Addr,
         mtu: u16,
     ) -> Self {
+        let free_ips = Arc::new(SegQueue::new());
+
+        // заполняем пул IP
+        let net = u32::from(network);
+        let mask = u32::from(netmask);
+
+        for host in 1..=u32::MAX {
+            let candidate = net | host;
+
+            if (candidate & mask) != (net & mask) {
+                break;
+            }
+
+            let ip = Ipv4Addr::from(candidate);
+
+            if ip == gateway || ip == server {
+                continue;
+            }
+
+            free_ips.push(ip);
+        }
+
+        let lease_time = Duration::from_secs(3600);
         Self {
             network,
             netmask,
             gateway,
             server,
             mtu,
-            used: Arc::new(DashSet::new()),
+            lease_time,
+            client_to_lease: Arc::new(DashMap::new()),
+            ip_to_lease: Arc::new(DashMap::new()),
+            free_ips,
         }
     }
 
-    pub fn allocate(&self) -> Option<Ipv4Addr> {
-        let net = u32::from(self.network);
-        let mask = u32::from(self.netmask);
-        let gw = self.gateway;
-        let srv = self.server;
+    pub fn allocate(&self, client_id: String) -> Option<Ipv4Addr> {
+        // 1. если уже есть lease
+        if let Some(entry) = self.client_to_lease.get(&client_id) {
+            let lease = entry.value();
 
-        for host in 1..=u32::MAX {
-            let candidate = net | host;
-            if (candidate & mask) != (net & mask) {
-                break;
-            }
-            let ip = Ipv4Addr::from(candidate);
-
-            if ip == gw || ip == srv {
-                continue;
-            }
-            if self.used.contains(&ip) {
-                continue;
+            if lease.expires_at > Instant::now() {
+                return Some(lease.ip);
             }
 
-            self.used.insert(ip);
-            return Some(ip);
+            // истёк — освобождаем
+            self.release(lease.ip);
         }
-        None
+
+        // 2. берём новый IP
+        let ip = self.free_ips.pop()?;
+
+        let lease = Lease {
+            ip,
+            client_id: client_id.clone(),
+            expires_at: Instant::now() + self.lease_time,
+        };
+
+        // 3. записываем
+        self.client_to_lease
+            .insert(client_id.clone(), lease.clone());
+        self.ip_to_lease.insert(ip, lease);
+
+        Some(ip)
     }
 
     pub fn release(&self, ip: Ipv4Addr) -> bool {
-        self.used.remove(&ip);
-        self.used.contains(&ip)
+        if let Some((_, lease)) = self.ip_to_lease.remove(&ip) {
+            self.client_to_lease.remove(&lease.client_id);
+            self.free_ips.push(ip);
+            return true;
+        }
+        false
     }
 }


### PR DESCRIPTION
- Раздается на основе client_id
Не уверен что правильно, потому что раст почти не трогал и писал это с помощью нейронки
Надо еще дописать логику renew чтобы пул ip не засирался (хотя не уверен, что будет столько клиентов чтобы закончился пул). Опять такие нанейрослопил базово функцию renew, но не знаю куда ее можно впихнуть.

Появилась в этом потребность, так как попробовал использовать anet как впн для домашней сети (есть свой подкроватный сервер), но вот встала проблема что ip слетает при перезапуске клиента 